### PR TITLE
Add wp-now for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 		"lint:js": "wp-scripts lint-js",
 		"packages-update": "wp-scripts packages-update",
 		"plugin-zip": "wp-scripts plugin-zip",
-		"start": "wp-scripts start --blocks-manifest"
+		"start": "wp-scripts start --blocks-manifest",
+		"serve": "npx @wp-now/wp-now start"
 	},
 	"devDependencies": {
 		"@wordpress/icons": "^10.22.0",


### PR DESCRIPTION
Fixes #7 

### Description

Add wp-now script for quickly spinning up a local test site by running a command `npm run serve`

### Testing instructions

* Checkout this branch and run `npm run serve`
* This will use `wp-now` script to create and open a test site with the BlaBlaBlocks Formats plugin enabled for testing