### PR TITLE
feat: add has format helper

### DIFF
--- a/blablablocks-formats.php
+++ b/blablablocks-formats.php
@@ -113,3 +113,38 @@ function blablablocks_formats_enqueue_assets()
 	}
 }
 add_action('enqueue_block_assets', 'blablablocks_formats_enqueue_assets');
+
+/**
+ * check if post has the given format
+ *
+ * @param string $format_class
+ * @param string $post
+ * @return boolean
+ */
+function blablablocks_has_format($format_class, $post = null)
+{
+	if( !$post ) {
+		$wp_post = get_post();
+		if ( $wp_post instanceof WP_Post ) {
+			$post = $wp_post->post_content;
+		}
+	}
+
+	if (trim($format_class) === '' || trim($post) === '') {
+        return false;
+    }
+
+    // Regex looks for the class inside any class attribute
+    $pattern = '/class\s*=\s*(["\'])(.*?)\1/i';
+
+    if (preg_match_all($pattern, $post, $matches)) {
+        foreach ($matches[2] as $classAttr) {
+            $classes = preg_split('/\s+/', $classAttr);
+            if (in_array($format_class, $classes, true)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}

--- a/src/infotip/index.js
+++ b/src/infotip/index.js
@@ -14,10 +14,10 @@ import { Edit } from './edit';
 /**
  * Registers the Infotip format type.
  */
-registerFormatType( 'blablablocks/infotip', {
-	title: __( 'Infotip', 'blablablocks-formats' ),
+registerFormatType('blablablocks/infotip', {
+	title: __('Infotip', 'blablablocks-formats'),
 	tagName: 'tatva-infotip',
-	className: 'has-infotip',
+	className: 'has-infotip-format',
 	edit: Edit,
 	attributes: {
 		content: 'content',
@@ -31,4 +31,4 @@ registerFormatType( 'blablablocks/infotip', {
 		'overlay-text-color': 'overlay-text-color',
 		'overlay-background-color': 'overlay-background-color',
 	},
-} );
+});

--- a/src/marker/index.js
+++ b/src/marker/index.js
@@ -14,10 +14,10 @@ import { Edit } from './edit';
 /**
  * Registers the Marker format type.
  */
-registerFormatType( 'blablablocks/marker', {
-	title: __( 'Marker', 'blablablocks-formats' ),
+registerFormatType('blablablocks/marker', {
+	title: __('Marker', 'blablablocks-formats'),
 	tagName: 'tatva-marker',
-	className: 'has-marker-text',
+	className: 'has-marker-format',
 	edit: Edit,
 	attributes: {
 		type: 'type',
@@ -26,4 +26,4 @@ registerFormatType( 'blablablocks/marker', {
 		'animation-function': 'animation-function',
 		color: 'color',
 	},
-} );
+});


### PR DESCRIPTION
### Summary
Adds a helper function to check if the format exists to conditionally load the asset.

e.g.
```
blablablocks_has_format('has-marker-text')
```

Will return true or false

### Related Issue
#72 

Will need follow-up PR to add logic to assets for conditional loading or update to this PR to handle the same!